### PR TITLE
ObjectCollection implementation

### DIFF
--- a/music_service_async_interface/__init__.py
+++ b/music_service_async_interface/__init__.py
@@ -19,10 +19,6 @@ def plural_noun(val):
     return val + "s"
 
 
-# TODO [#5]: Specify how to implement collections of collections of tracks
-#   eg. user containing playlists containing tracks or artist containing albums containing tracks
-
-
 class InvalidURL(Exception):
     pass
 
@@ -88,9 +84,9 @@ class Session(ABC):
     @abstractmethod
     def __init__(self, sess: Optional[aiohttp.ClientSession] = None):
         if not hasattr(self.__class__, "_obj"):
-            raise TypeError(f"Can't instantiate abstract class {self.__class__} with abstract property obj")
+            raise TypeError(f"Can't instantiate abstract class {self.__class__} with abstract property _obj")
         if not hasattr(self.__class__, "_quality"):
-            raise TypeError(f"Can't instantiate abstract class {self.__class__} with abstract property quality")
+            raise TypeError(f"Can't instantiate abstract class {self.__class__} with abstract property _quality")
 
         self.sess = aiohttp.ClientSession() if sess is None else sess
         self._required_audio_quality: AudioQuality = min(self._quality)
@@ -217,7 +213,6 @@ class Track(Object, ABC):
         self,
         required_quality: Optional[AudioQuality] = None,
         preferred_quality: Optional[AudioQuality] = None,
-        *args,
         **kwargs,
     ) -> str:
         """This method asks service for music file url
@@ -236,7 +231,6 @@ class Track(Object, ABC):
             required_quality: Optional[AudioQuality] = None,
             preferred_quality: Optional[AudioQuality] = None,
             filename: Optional[str] = None,
-            *args,
             **kwargs,
         ) -> AsyncSeekableHTTPFile:
             """Gets async `filelike` object for Track
@@ -249,7 +243,7 @@ class Track(Object, ABC):
             """
 
             return await AsyncSeekableHTTPFile.create(
-                await self.get_file_url(required_quality, preferred_quality, *args, **kwargs),
+                await self.get_file_url(required_quality, preferred_quality, **kwargs),
                 self.title if filename is None else filename,
                 self.sess.sess,
             )
@@ -268,7 +262,7 @@ class ObjectCollection:
         if not issubclass(collection_type, Object):
             raise TypeError(f"index must be subclass of Object, not {collection_type}")
 
-        class CollectionHelper(ABC):
+        class CollectionHelper:
             collection_of: Set[Type[Object]] = set()
 
             def __init_subclass__(cls, **kwargs):

--- a/music_service_async_interface/__init__.py
+++ b/music_service_async_interface/__init__.py
@@ -257,16 +257,16 @@ class TrackCollection(Object, ABC):
 
 class TrackCollectionSet:
     def __new__(cls):
-        raise TypeError(f"You can't directly spawn this class. Use {cls.__name__}[YourTrackCollection]")
+        raise TypeError(f"Can't instantiate this class directly. Try {cls.__name__}[TrackCollection]")
 
     def __init_subclass__(cls):
-        raise TypeError("You can't directly subclass this class. Use TrackCollectionSet[YourTrackCollection]")
+        raise TypeError("Can't subclass this class directly. Try TrackCollectionSet[TrackCollection]")
 
     @classmethod
     @lru_cache
     def __class_getitem__(cls, collection_type: Type[TrackCollection]):
         if not issubclass(collection_type, TrackCollection):
-            raise TypeError(f"collection_type need to be subclass of TrackCollection, got {collection_type} instead")
+            raise TypeError(f"index must be subclass of TrackCollection, not {collection_type}")
 
         async def _load_collections(self) -> AsyncGenerator[TrackCollection, None]:
             ...


### PR DESCRIPTION
It looks like it works pretty good :D 

```python
from music_service_async_interface import Object, TrackCollection, TrackCollectionSet

class Album(TrackCollection):
    from_id = from_url = get_id = get_url = lambda *a, **b: None

class Playlist(TrackCollection):
    from_id = from_url = get_id = get_url = lambda *a, **b: None

class Whatever:
    pass

TrackCollectionSet[Whatever]
Traceback (most recent call last):
    raise TypeError(f"collection_type need to be subclass of TrackCollection, got {collection_type} instead")
TypeError: collection_type need to be subclass of TrackCollection, got <class '__main__.Whatever'> instead

TrackCollectionSet[Album]
Out: music_service_async_interface.TrackCollectionSet[Album]

TrackCollectionSet[Album] == TrackCollectionSet[Album]
Out: True

TrackCollectionSet[Album] == TrackCollectionSet[Playlist]
Out: False

class Artist(TrackCollectionSet[Album]):
    from_id = from_url = get_id = get_url = lambda *a, **b: None

Artist()
Traceback (most recent call last):
    Artist()
TypeError: Can't instantiate abstract class Artist with abstract methods albums

class Artist(TrackCollectionSet[Album]):
    from_id = from_url = get_id = get_url = albums = lambda *a, **b: None

Artist()
Out: <__main__.Artist at 0x7f79030e8ee0>

class Artist(TrackCollectionSet[Playlist]):
    from_id = from_url = get_id = get_url = albums = lambda *a, **b: None

Artist()
Traceback (most recent call last):
    Artist()
TypeError: Can't instantiate abstract class Artist with abstract methods playlists

class Artist(TrackCollectionSet[Album], TrackCollectionSet[Playlist]):
    from_id = from_url = get_id = get_url = lambda *a, **b: None

Artist()
Traceback (most recent call last):
    Artist()
TypeError: Can't instantiate abstract class Artist with abstract methods albums, playlists


```